### PR TITLE
Make it return the entire sha1 hash even when there's a leading 0 on the hash

### DIFF
--- a/android/src/main/java/com/reactlibrary/Sha1Module.java
+++ b/android/src/main/java/com/reactlibrary/Sha1Module.java
@@ -33,9 +33,8 @@ public class Sha1Module extends ReactContextBaseJavaModule {
       MessageDigest md = null;
       try {
           md = MessageDigest.getInstance("SHA-1");
-          md.update(toHash.getBytes("UTF-8"));
-          byte[] digest = md.digest();
-          String hash = String.format("%02X", new java.math.BigInteger(1, digest));
+          md.update(toHash.getBytes("UTF-8"), 0, toHash.length());
+          String hash = String.format("%040x", new java.math.BigInteger(1, md.digest()));
           promise.resolve(hash);
 
       } catch (NoSuchAlgorithmException e) {
@@ -46,5 +45,4 @@ public class Sha1Module extends ReactContextBaseJavaModule {
           promise.reject("sha1", e.getMessage());
       }
   }
-
 }


### PR DESCRIPTION
So, when creating a hash there's a problem that when it starts with a 0, java supresses it, creating a 39 caracthers sha1 hash.
This PR fixes it!